### PR TITLE
Bind mariadb instance to localhost

### DIFF
--- a/etc/sql/mariadb.cnf
+++ b/etc/sql/mariadb.cnf
@@ -18,7 +18,7 @@ tmpdir        = /tmp
 lc_messages_dir    = /usr/share/mysql
 lc_messages    = en_US
 skip-external-locking
-bind-address        = 0.0.0.0 
+bind-address        = 127.0.0.1
 max_connections        = 100
 connect_timeout        = 5
 wait_timeout        = 600


### PR DESCRIPTION
This commit set default mariadb ip address to 127.0.0.1 in default config file