### PR TITLE
Update OpenPhish feed URL to new GitHub location

### DIFF
--- a/etc/n6/60_openphish.conf
+++ b/etc/n6/60_openphish.conf
@@ -6,7 +6,7 @@
 # Collector
 
 [OpenphishWebBlCollector]
-url=https://openphish.com/feed.txt
+url=https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt
 download_retries = 1
 
 


### PR DESCRIPTION
This PR updates the OpenPhish feed URL to point to their new GitHub-hosted location.

The original feed URL occasionally becomes unavailable, while the GitHub-based feed is now officially listed as a reliable alternative.

Switching to the GitHub feed ensures better reliability and availability of threat intelligence data.