### PR TITLE
Update docker-compose.yml examples to use Compose v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,19 @@
 # docker-compose for public n6
 
 # Basic Commands
-# docker-compose build
-# docker-compose up
+# docker compose build
+# docker compose up
 
 # Prepare Auth DB
-# docker-compose run --rm worker n6/docker/bin/wait-for-services.sh
-# docker-compose run --rm worker n6create_and_initialize_auth_db -D -y
-# docker-compose run --rm worker n6populate_auth_db -F -i -t -s -p example.com login@example.com
+# docker compose run --rm worker n6/docker/bin/wait-for-services.sh
+# docker compose run --rm worker n6create_and_initialize_auth_db -D -y
+# docker compose run --rm worker n6populate_auth_db -F -i -t -s -p example.com login@example.com
 
 # On MySQL Changes - restart web cache
-# docker-compose exec web apache2ctl restart
+# docker compose exec web apache2ctl restart
 
 # Cleanup
-# docker-compose down -v
+# docker compose down -v
 
 version: "3.7"
 services:


### PR DESCRIPTION
As of commit https://github.com/CERT-Polska/n6/commit/35117913da19c16d578a3a399ca3d00f95049287, `docker-compose.yml` contains `additional_contexts` which [requires Compose v2](https://docs.docker.com/reference/compose-file/build/#additional_contexts).

This PR changes commented examples with old `docker-compose` commands, which may let users use [unsupported Compose v1](https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2), with newer `docker compose`.